### PR TITLE
Dynamic Client Registration

### DIFF
--- a/lib/e3db/client.rb
+++ b/lib/e3db/client.rb
@@ -72,6 +72,16 @@ module E3DB
     attribute :validated, Types::Strict::Bool
   end
 
+  # Information about a newly-created E3DB client
+
+  class ClientDetails < Dry::Struct
+    attribute :client_id, Types::Strict::String
+    attribute :api_key_id, Types::Strict::String
+    attribute :api_secret, Types::Strict::String
+    attribute :public_key, PublicKey
+    attribute :name, Types::Strict::String
+  end
+
   # Meta-information about an E3DB record, such as who wrote it,
   # when it was written, and the type of data stored.
   #
@@ -172,6 +182,20 @@ module E3DB
   #   @return [Config] the client configuration object
   class Client
     attr_reader :config
+
+    def self.register(registration_token, client_name, public_key, api_url=E3DB::DEFAULT_API_URL)
+      url = sprintf('%s/%s', api_url.chomp('/'), 'v1/account/e3db/clients/register')
+      payload = JSON.generate({:token => registration_token, :client => {:name => client_name, :public_key => {:curve25519 => public_key.curve25519}}})
+
+      conn = Faraday.new(api_url) do |faraday|
+        faraday.request :json
+        faraday.response :raise_error
+        faraday.adapter :net_http_persistent
+      end
+
+      resp = conn.post(url, payload)
+      ClientDetails.new(JSON.parse(resp.body, symbolize_names: true))
+    end
 
     # Create a connection to the E3DB service given a configuration.
     #

--- a/lib/e3db/client.rb
+++ b/lib/e3db/client.rb
@@ -183,6 +183,13 @@ module E3DB
   class Client
     attr_reader :config
 
+    # Register a new client with a specific account given that account's registration token
+    #
+    # @param registration_token [String] Token for a specific InnoVault account
+    # @param client_name        [String] Unique name for the client being registered
+    # @param public_key         [String] Base64URL-encoded public key component of a Curve25519 keypair
+    # @param api_url            [String] Optional URL of the API against which to register
+    # @return [ClientDetails] Credentials and details about the newly-created client
     def self.register(registration_token, client_name, public_key, api_url=E3DB::DEFAULT_API_URL)
       url = sprintf('%s/%s', api_url.chomp('/'), 'v1/account/e3db/clients/register')
       payload = JSON.generate({:token => registration_token, :client => {:name => client_name, :public_key => {:curve25519 => public_key.curve25519}}})
@@ -195,6 +202,15 @@ module E3DB
 
       resp = conn.post(url, payload)
       ClientDetails.new(JSON.parse(resp.body, symbolize_names: true))
+    end
+
+    # Generate a random Curve25519 keypair
+    #
+    # @return [String, String] Public and private keys (respectively) for the new keypair
+    def self.generate_keypair
+      keys = RbNaCl::PrivateKey.generate
+
+      return Crypto.encode_public_key(keys.public_key), Crypto.encode_private_key(keys)
     end
 
     # Create a connection to the E3DB service given a configuration.


### PR DESCRIPTION
Update the SDK to support the new programmatic registration endpoints. Also add tests to ensure clients can register with these endpoints.

Update the rest of the integration tests to use dynamically-created clients for both writing and sharing. Two tests leverage email-based lookups of client information and will not work with the dynamic clients until email-based lookups are implemented for that style of client.

Fixes E3DB-661