### PR TITLE
Automatically backup clients if requested

### DIFF
--- a/examples/registration.rb
+++ b/examples/registration.rb
@@ -41,6 +41,14 @@ puts("Client Name: " + client_name)
 # a new client with the system. Remember to keep your private key private!
 client_info = E3DB::Client.register(token, client_name, wrapped_key)
 
+# Optionally, you can automatically back up the credentials of the newly-created
+# client to your InnoVault account (accessible via https://console.tozny.com) by
+# passing your private key and a backup flag when registering. The private key is
+# not sent anywhere, but is used by the newly-created client to sign an encrypted
+# copy of its credentials that is itself stored in e3db for later use.
+
+# client_info = E3DB::Client.register(token, client_name, wrapped_key, private_key, true)
+
 puts("Client ID:   " + client_info.client_id)
 puts("API Key ID:  " + client_info.api_key_id)
 puts("API Secret:  " + client_info.api_secret)

--- a/examples/registration.rb
+++ b/examples/registration.rb
@@ -46,6 +46,8 @@ client_info = E3DB::Client.register(token, client_name, wrapped_key)
 # passing your private key and a backup flag when registering. The private key is
 # not sent anywhere, but is used by the newly-created client to sign an encrypted
 # copy of its credentials that is itself stored in e3db for later use.
+#
+# Client credentials are not backed up by default.
 
 # client_info = E3DB::Client.register(token, client_name, wrapped_key, private_key, true)
 

--- a/lib/e3db/client.rb
+++ b/lib/e3db/client.rb
@@ -206,7 +206,11 @@ module E3DB
       client_info = ClientDetails.new(JSON.parse(resp.body, symbolize_names: true))
       backup_client_id = resp.headers['x-backup-client']
 
-      if backup && ! private_key.nil?
+      if backup
+        if private_key.nil
+          raise 'Cannot back up client credentials without a private key!'
+        end
+
         # Instantiate a client
         config = E3DB::Config.new(
             :version      => 1,

--- a/lib/e3db/client.rb
+++ b/lib/e3db/client.rb
@@ -188,6 +188,8 @@ module E3DB
     # @param registration_token [String]  Token for a specific InnoVault account
     # @param client_name        [String]  Unique name for the client being registered
     # @param public_key         [String]  Base64URL-encoded public key component of a Curve25519 keypair
+    # @param private_key        [String]  Optional Curve25519 private key component used to sign the backup key
+    # @param backup             [Boolean] Optional flag to automatically back up the newly-created credentials to the account service
     # @param api_url            [String]  Optional URL of the API against which to register
     # @return [ClientDetails] Credentials and details about the newly-created client
     def self.register(registration_token, client_name, public_key, private_key=nil, backup=true, api_url=E3DB::DEFAULT_API_URL)
@@ -214,7 +216,7 @@ module E3DB
             :client_email => '',
             :public_key   => public_key.curve25519,
             :private_key  => private_key,
-            :api_url      => 'https://dev.e3db.com',
+            :api_url      => 'https://api.e3db.com',
             :logging      => false
         )
         client = E3DB::Client.new(config)

--- a/lib/e3db/client.rb
+++ b/lib/e3db/client.rb
@@ -192,7 +192,7 @@ module E3DB
     # @param backup             [Boolean] Optional flag to automatically back up the newly-created credentials to the account service
     # @param api_url            [String]  Optional URL of the API against which to register
     # @return [ClientDetails] Credentials and details about the newly-created client
-    def self.register(registration_token, client_name, public_key, private_key=nil, backup=true, api_url=E3DB::DEFAULT_API_URL)
+    def self.register(registration_token, client_name, public_key, private_key=nil, backup=false, api_url=E3DB::DEFAULT_API_URL)
       url = sprintf('%s/%s', api_url.chomp('/'), 'v1/account/e3db/clients/register')
       payload = JSON.generate({:token => registration_token, :client => {:name => client_name, :public_key => {:curve25519 => public_key.curve25519}}})
 

--- a/lib/e3db/client.rb
+++ b/lib/e3db/client.rb
@@ -185,12 +185,12 @@ module E3DB
 
     # Register a new client with a specific account given that account's registration token
     #
-    # @param registration_token [String] Token for a specific InnoVault account
-    # @param client_name        [String] Unique name for the client being registered
-    # @param public_key         [String] Base64URL-encoded public key component of a Curve25519 keypair
-    # @param api_url            [String] Optional URL of the API against which to register
+    # @param registration_token [String]  Token for a specific InnoVault account
+    # @param client_name        [String]  Unique name for the client being registered
+    # @param public_key         [String]  Base64URL-encoded public key component of a Curve25519 keypair
+    # @param api_url            [String]  Optional URL of the API against which to register
     # @return [ClientDetails] Credentials and details about the newly-created client
-    def self.register(registration_token, client_name, public_key, api_url=E3DB::DEFAULT_API_URL)
+    def self.register(registration_token, client_name, public_key, private_key=nil, backup=true, api_url=E3DB::DEFAULT_API_URL)
       url = sprintf('%s/%s', api_url.chomp('/'), 'v1/account/e3db/clients/register')
       payload = JSON.generate({:token => registration_token, :client => {:name => client_name, :public_key => {:curve25519 => public_key.curve25519}}})
 
@@ -201,7 +201,29 @@ module E3DB
       end
 
       resp = conn.post(url, payload)
-      ClientDetails.new(JSON.parse(resp.body, symbolize_names: true))
+      client_info = ClientDetails.new(JSON.parse(resp.body, symbolize_names: true))
+      backup_client_id = resp.headers['x-backup-client']
+
+      if backup
+        # Instantiate a client
+        config = E3DB::Config.new(
+            :version      => 1,
+            :client_id    => client_info.client_id,
+            :api_key_id   => client_info.api_key_id,
+            :api_secret   => client_info.api_secret,
+            :client_email => '',
+            :public_key   => public_key.curve25519,
+            :private_key  => private_key,
+            :api_url      => 'https://dev.e3db.com',
+            :logging      => false
+        )
+        client = E3DB::Client.new(config)
+
+        # Back the client up
+        client.backup(backup_client_id, registration_token)
+      end
+
+      client_info
     end
 
     # Generate a random Curve25519 keypair
@@ -342,6 +364,31 @@ module E3DB
     # @param record_id [String] unique ID of record to delete
     def delete(record_id)
       resp = @conn.delete(get_url('v1', 'storage', 'records', record_id))
+    end
+
+    # Back up the client's configuration to E3DB in a serialized format that can be read
+    # by the Admin Console. The stored configuration will be shared with the specified client,
+    # and the account service notified that the sharing has taken place.
+    #
+    # @param client_id          [String] Unique ID of the client to which we're backing up
+    # @param registration_token [String] Original registration token used to create the client
+    def backup(client_id, registration_token)
+      credentials = {
+          :version      => '1',
+          :client_id    => @config.client_id.to_json,
+          :api_key_id   => @config.api_key_id.to_json,
+          :api_secret   => @config.api_secret.to_json,
+          :client_email => @config.client_email.to_json,
+          :public_key   => @config.public_key.to_json,
+          :private_key  => @config.private_key.to_json,
+          :api_url      => @config.api_url.to_json
+      }
+
+      write('tozny.key_backup', credentials, {:client => @config.client_id})
+      share('tozny.key_backup', client_id)
+
+      url = get_url('v1', 'account', 'backup', registration_token, @config.client_id)
+      @conn.post(url)
     end
 
     class Query < Dry::Struct

--- a/lib/e3db/client.rb
+++ b/lib/e3db/client.rb
@@ -206,7 +206,7 @@ module E3DB
       client_info = ClientDetails.new(JSON.parse(resp.body, symbolize_names: true))
       backup_client_id = resp.headers['x-backup-client']
 
-      if backup
+      if backup && ! private_key.nil?
         # Instantiate a client
         config = E3DB::Config.new(
             :version      => 1,

--- a/spec/e3db_spec.rb
+++ b/spec/e3db_spec.rb
@@ -5,8 +5,8 @@ describe E3DB do
   token = ENV["REGISTRATION_TOKEN"]
   api_url = ENV["API_URL"]
 
-  client1_private_key, client1_public_key = E3DB::Client.generate_keypair
-  client2_private_key, client2_public_key = E3DB::Client.generate_keypair
+  client1_public_key, client1_private_key = E3DB::Client.generate_keypair
+  client2_public_key, client2_private_key = E3DB::Client.generate_keypair
 
   client1_public_key = E3DB::PublicKey.new(:curve25519 => client1_public_key)
   client1_name = sprintf("test_client_%s", SecureRandom.hex)

--- a/spec/e3db_spec.rb
+++ b/spec/e3db_spec.rb
@@ -234,7 +234,7 @@ describe E3DB do
     })
     client.share(type, test_share_client)
 
-    rec2 = test_share_client.read(rec.meta.record_id)
+    rec2 = client2.read(rec.meta.record_id)
     expect(rec.data).to eq(rec2.data)
   end
 

--- a/spec/e3db_spec.rb
+++ b/spec/e3db_spec.rb
@@ -13,8 +13,8 @@ describe E3DB do
   client2_public_key = E3DB::PublicKey.new(:curve25519 => client2_public_key)
   client2_name = sprintf("share_client_%s", SecureRandom.hex)
 
-  test_client1 = E3DB::Client.register(token, client1_name, client1_public_key, api_url)
-  test_client2 = E3DB::Client.register(token, client2_name, client2_public_key, api_url)
+  test_client1 = E3DB::Client.register(token, client1_name, client1_public_key, nil, false, api_url)
+  test_client2 = E3DB::Client.register(token, client2_name, client2_public_key, nil, false, api_url)
 
   opts = E3DB::Config.new(
     :version      => 1,
@@ -52,7 +52,7 @@ describe E3DB do
     public_key = E3DB::PublicKey.new(:curve25519 => public_key)
     name = sprintf("client_%s", SecureRandom.hex)
 
-    test_client = E3DB::Client.register(token, name, public_key, api_url)
+    test_client = E3DB::Client.register(token, name, public_key, nil, false, api_url)
 
     expect(test_client.name).to eq(name)
     expect(test_client.public_key.curve25519).to eq(public_key.curve25519)

--- a/spec/e3db_spec.rb
+++ b/spec/e3db_spec.rb
@@ -233,6 +233,9 @@ describe E3DB do
       :timestamp => DateTime.now.iso8601
     })
     client.share(type, test_share_client)
+
+    rec2 = test_share_client.read(rec.meta.record_id)
+    expect(rec.data).to eq(rec2.data)
   end
 
   # Ignoring test for now until dynamic clients can be referenced by email address


### PR DESCRIPTION
Add a `Client::backup()` routine to back newly-created clients up to the Admin Console's backup client (via the Account Service).

Fixes [E3DB-684](https://toznysecurity.atlassian.net/browse/E3DB-684)