### PR TITLE
Use encoded public key for registration not object

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ also copy it to your \Windows\System32 directory.
 
 ## Registering a client
 
-Register an account with [InnoVault](https://inoovault.io) to get started. From the Admin Console you can create clients directly (and grab their credentials from the console) or create registration tokens to dynamically create clients with `E3DB::Client.register()`. Clients registered from within the console will automatically back their credentials up to your account. Clients created dynamically via the SDK can _optionally_ back their credentials up to your account.
+Register an account with [InnoVault](https://innovault.io) to get started. From the Admin Console you can create clients directly (and grab their credentials from the console) or create registration tokens to dynamically create clients with `E3DB::Client.register()`. Clients registered from within the console will automatically back their credentials up to your account. Clients created dynamically via the SDK can _optionally_ back their credentials up to your account.
 
 For a more complete walkthrough, see [`/examples/registration.rb`](https://github.com/tozny/e3db-ruby/blob/master/examples/registration.rb).
 
@@ -55,21 +55,19 @@ token = '...'
 client_name = '...'
 
 public_key, private_key = E3DB::Client.generate_keypair
-wrapped_key = E3DB::PublicKey.new(:curve25519 => public_key)
-client_info = E3DB::Client.register(token, client_name, wrapped_key)
+client_info = E3DB::Client.register(token, client_name, public_key)
 ```
 
 The object returned from the server contains the client's UUID, API key, and API secret (as well as echos back the public key passed during registration). It's your responsibility to store this information locally as it _will not be recoverable_ without credential backup.
 
 ### With Credential Backup
-   
+
 ```ruby
 token = '...'
 client_name = '...'
 
 public_key, private_key = E3DB::Client.generate_keypair
-wrapped_key = E3DB::PublicKey.new(:curve25519 => public_key)
-client_info = E3DB::Client.register(token, client_name, wrapped_key, private_key, true)
+client_info = E3DB::Client.register(token, client_name, public_key, private_key, true)
 ```
 
 The private key must be passed to the registration handler when backing up credentials as it is used to cryptographically sign the encrypted backup file stored on the server. The private key never leaves the system, and the stored credentials will only be accessible to the newly-registered client itself or the account with which it is registered.
@@ -160,13 +158,9 @@ See the [simple example code](examples/simple.rb) for runnable detailed examples
 
 ## Development
 
-Before running tests, register an `integration-test` profile using
-the E3DB command-line tool:
-
-```shell
-$ e3db -p integration-test register me+test@mycompany.com
-$ e3db -p integration-test-share register --public=true me+test2@mycompany.com
-```
+Before running tests, register an account with
+[InnoVault](https://innovault.io), and generate a client. Export the client
+token as the environment variable `REGISTRATION_TOKEN`.
 
 After checking out the repo, run `bin/setup` to install dependencies. Then,
 run `rake spec` to run the tests. You can also run `bin/console` for an

--- a/examples/registration.rb
+++ b/examples/registration.rb
@@ -26,10 +26,6 @@ public_key, private_key = E3DB::Client.generate_keypair
 puts("Public Key:  " + public_key)
 puts("Private Key: " + private_key)
 
-# The e3db server keeps track of the name of the curve used with public keys,
-# so we need to wrap the generated version with an object helper
-wrapped_key = E3DB::PublicKey.new(:curve25519 => public_key)
-
 # Clients must be registered with a name unique to your account to help
 # differentiate between different sets of credentials in the Admin Console.
 # In this example, the name is set at random
@@ -39,7 +35,7 @@ puts("Client Name: " + client_name)
 
 # Passing all of the data above into the registration routine will create
 # a new client with the system. Remember to keep your private key private!
-client_info = E3DB::Client.register(token, client_name, wrapped_key)
+client_info = E3DB::Client.register(token, client_name, public_key)
 
 # Optionally, you can automatically back up the credentials of the newly-created
 # client to your InnoVault account (accessible via https://console.tozny.com) by

--- a/lib/e3db/client.rb
+++ b/lib/e3db/client.rb
@@ -188,13 +188,13 @@ module E3DB
     # @param registration_token [String]  Token for a specific InnoVault account
     # @param client_name        [String]  Unique name for the client being registered
     # @param public_key         [String]  Base64URL-encoded public key component of a Curve25519 keypair
-    # @param private_key        [String]  Optional Curve25519 private key component used to sign the backup key
+    # @param private_key        [String]  Optional Base64URL-encoded private key component of a Curve25519 keypair
     # @param backup             [Boolean] Optional flag to automatically back up the newly-created credentials to the account service
     # @param api_url            [String]  Optional URL of the API against which to register
     # @return [ClientDetails] Credentials and details about the newly-created client
     def self.register(registration_token, client_name, public_key, private_key=nil, backup=false, api_url=E3DB::DEFAULT_API_URL)
       url = sprintf('%s/%s', api_url.chomp('/'), 'v1/account/e3db/clients/register')
-      payload = JSON.generate({:token => registration_token, :client => {:name => client_name, :public_key => {:curve25519 => public_key.curve25519}}})
+      payload = JSON.generate({:token => registration_token, :client => {:name => client_name, :public_key => {:curve25519 => public_key}}})
 
       conn = Faraday.new(api_url) do |faraday|
         faraday.request :json
@@ -218,7 +218,7 @@ module E3DB
             :api_key_id   => client_info.api_key_id,
             :api_secret   => client_info.api_secret,
             :client_email => '',
-            :public_key   => public_key.curve25519,
+            :public_key   => public_key,
             :private_key  => private_key,
             :api_url      => api_url,
             :logging      => false
@@ -234,7 +234,7 @@ module E3DB
 
     # Generate a random Curve25519 keypair
     #
-    # @return [String, String] Public and private keys (respectively) for the new keypair
+    # @return [String, String] Base64URL-encoded public and private keys (respectively) for the new keypair
     def self.generate_keypair
       keys = RbNaCl::PrivateKey.generate
 

--- a/spec/e3db_spec.rb
+++ b/spec/e3db_spec.rb
@@ -8,9 +8,7 @@ describe E3DB do
   client1_public_key, client1_private_key = E3DB::Client.generate_keypair
   client2_public_key, client2_private_key = E3DB::Client.generate_keypair
 
-  client1_public_key = E3DB::PublicKey.new(:curve25519 => client1_public_key)
   client1_name = sprintf("test_client_%s", SecureRandom.hex)
-  client2_public_key = E3DB::PublicKey.new(:curve25519 => client2_public_key)
   client2_name = sprintf("share_client_%s", SecureRandom.hex)
 
   test_client1 = E3DB::Client.register(token, client1_name, client1_public_key, nil, false, api_url)
@@ -22,7 +20,7 @@ describe E3DB do
     :api_key_id   => test_client1.api_key_id,
     :api_secret   => test_client1.api_secret,
     :client_email => sprintf('eric+%s@tozny.com', test_client1.name),
-    :public_key   => test_client1.public_key.curve25519,
+    :public_key   => client1_public_key,
     :private_key  => client1_private_key,
     :api_url      => api_url,
     :logging      => false
@@ -36,7 +34,7 @@ describe E3DB do
       :api_key_id   => test_client2.api_key_id,
       :api_secret   => test_client2.api_secret,
       :client_email => sprintf('eric+%s@tozny.com', test_client2.name),
-      :public_key   => test_client2.public_key.curve25519,
+      :public_key   => client2_public_key,
       :private_key  => client2_private_key,
       :api_url      => api_url,
       :logging      => false
@@ -49,13 +47,12 @@ describe E3DB do
 
   it 'can register clients' do
     public_key, _ = E3DB::Client.generate_keypair
-    public_key = E3DB::PublicKey.new(:curve25519 => public_key)
     name = sprintf("client_%s", SecureRandom.hex)
 
     test_client = E3DB::Client.register(token, name, public_key, nil, false, api_url)
 
     expect(test_client.name).to eq(name)
-    expect(test_client.public_key.curve25519).to eq(public_key.curve25519)
+    expect(test_client.public_key.curve25519).to eq(public_key)
 
     expect(test_client.client_id).not_to be equal("")
     expect(test_client.api_key_id).not_to be equal("")


### PR DESCRIPTION
- Flattens interface to registration
- Updates references in README, examples, and tests